### PR TITLE
Added a possibility to set a custom name to the click event

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ You can send a click event with the following directive:
 The following data can be passed to v-amplitude click:
 
 route (required - a vue router route object)
+name (optional – a custom event name)
 description (required - a string description)
 destination (optional - where this button takes the user to)
 section (optional - section this object appears on the page)
 
 Example:
 
-    <button v-amplitude-click="{route: this.$route, description: 'Login Button', destination: 'http://github.com', section: 'footer'}" />
+    <button v-amplitude-click="{route: this.$route, name: 'Submit Shipping Method', description: 'Login Button', destination: 'http://github.com', section: 'footer'}" />
 
 The following data will also be set by default for every click event: 
 - page

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,9 @@ class _PageLoadEvent extends _Event {
 }
 
 class _ClickEvent extends _Event {
-  constructor(description, destination, section, global_event_properties) {
+  constructor(name = null, description, destination, section, global_event_properties) {
     super(global_event_properties);
-    this.name = "click";
+    this.name = name || 'click';
     this.properties = {
       'ITEM-DESCRIPTION': description,
       'LINK-DESTINATION': destination,
@@ -104,7 +104,7 @@ class VueAmplitude {
     }
   }
 
-  clickEvent({ route, description, destination=null, section=null }) {
+  clickEvent({ route, name, description, destination=null, section=null }) {
     if (this._initialized !== true) {
       console.error("init must be called for Amplitude before calling clickEvent");
       return;
@@ -117,7 +117,7 @@ class VueAmplitude {
       return;
     }
     const geps = _getGlobalEventProperties(route);
-    const event = new _ClickEvent(description, destination, section, geps);
+    const event = new _ClickEvent(name, description, destination, section, geps);
     event.sendEvent();
 
     if (this._debug) {


### PR DESCRIPTION
I've faced with a necessity to specify a click event name to specify right taxonomy for my project. There wasn't this possibility and I've tried to add.